### PR TITLE
Issue #1 Solution

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. The properties for 'orderItem' and 'quantity' in the order form are now properly set to event.target.value rather than event.value whenever a change is made to those selections.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/1
- Description: The order form was not successfully submitting orders, and was returning a 400 status code when attempting to call the add-order endpoint.

## Approach
_How does this change address the problem?_
- This change fixes a coding error where 'orderItem' and 'quantity' were always being set to undefined. The property 'value' does not exist on the event, the value needed to be extracted from 'event.target.value' instead.

## Pre-Testing TODOs
_What needs to be done before testing_
- There are no pre-testing steps for this fix.

## Testing Steps
_How do the users test this change?_
1. Change the order item on the order form.
2. Change the quantity on the order form.
3. Submit the order, then navigate to the "View Orders" page to confirm that your order is displayed.

## Learning
_Describe the research stage_

- Debug Steps:
1. Attempt to place an order and check Chrome's network tab to see if the add-order endpoint is being called. If so, check for any errors.
2. After realizing the endpoint is being called, I notice the endpoint is returning a 400 status code with the error message "No order item sent."
3. I notice in the order form that both 'orderItem' and 'quantity' are being set by an onChange event whenever a selection is made.
4. Now that the location of where 'orderItem' is being set has been identified, I see that it is being set to 'event.value' when it should be 'event.target.value'.
5. Due to 'quantity' having a default value set (1), it actually submits the order without an error after making the fix for 'orderItem'. However, if you change the quantity value, it will then be set to undefined and we get the expected "No quantity sent." error. So the fix needs to be made for 'quantity' as well.

- Additional confirmation for the fix:
1. You can console log 'event.nativeEvent' where 'orderItem' and 'quantity' are set, making it easy to see that there is no 'value' property for the event. Instead, there is a 'target' property that contains the value of the selected order item.
2. When submitting an order, you can also check the server's console logs (or your browser's Network tab) to confirm a successful 200 response from the add-order POST request.

Closes Shift3#1
