### PR TITLE
Issue #2 Solution

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -17,7 +17,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${createdDate.toLocaleTimeString([], {hour12: false})}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. The time display for an order's creation date has been changed to use `Date.toLocaleTimeString()`, rather than manually displaying the hours, minutes, and seconds.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/2
- Description: Manually displaying the number for hours, minutes, and seconds led to the display not properly zero-padding the minutes and seconds. For example, what should have been '20:02:53' was displayed as '20:2:53'.

## Approach
_How does this change address the problem?_

Using a built in time formatter for date objects ensures that our output will be exactly as expected based on the options we provide for that formatter tool. In this case, we provide the option `hour12: false` so that our display is always in a 24-hour format.

## Pre-Testing TODOs
_What needs to be done before testing_
- [ ] Make sure there is at least one order in the database with a creation date that has minutes/seconds that are less than 10.

## Testing Steps
_How do the users test this change?_
1. Navigate to the 'view-orders' page.
2. Check the time for when an order was placed (one with minutes/seconds less than 10).
3. Make sure the order shows the time with proper zero-padding (ex: '20:02:05').

## Learning
_Describe the research stage_
1. Look into the different formatting methods available on Date objects.
2. Find documentation (linked below) for `Date.toLocaleTimeString()`, which appears to be the exact type of formatting that we need since it allows us to provide options as an argument for the format.
3. Find on that documentation that we can provide an empty array for locale in order to keep the default, and an options argument with `hour12: false` in order to keep the time in a 24-hour format.

_Links to blog posts, patterns, libraries or addons used to solve this problem_
[Mozilla Developer Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString)

Closes Shift3#2
