### PR TITLE
Issue #4 Solution

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. This change to 'authReducer' sets the email that gets stored in state from `action.payload.login` to `action.payload.email`.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/4
- Description: When submitting an order, the 'order_by' property is never being set to the email of the authenticated user. Instead, it is always defaulting to 'Unknown!'.

## Approach
_How does this change address the problem?_

When submitting an order, the 'order_by' property is being set to `auth.email` (if it exists). When a user logs in, their email and token is dispatched and stored in state with a type and a payload (type being 'login' and the payload being an object that contains properties for `email` and `token`). However, when authReducer runs to store that payload into state, it sets the email property in state to `action.payload.login`. The issue here is that `login` does not exist in the payload, it should be `email`.

## Pre-Testing TODOs
_What needs to be done before testing_
- [ ] Login via the login page before submitting an order. This is necessary for your email to be stored in state.

## Testing Steps
_How do the users test this change?_
1. Login via the login page with any email address and password.
2. Submit a new order from the order form.
3. Go to the view-orders page and confirm that the new order shows your login email address in the "Ordered by" section.

## Learning
_Describe the research stage_

1. While looking through the `redux` folder in the repo, I check to see where dispatch is being called in order to update state with auth information.
2. After finding that dispatch is called within `authActions`, I notice that the action object contains properties for the type (which is 'login') and a payload (which contains the properties `email` and `token`).
3. I check the reducer function to make sure state is being updated, and notice that the email property in state is being set to `action.payload.login`. The issue is that `login` was not a property in our payload, and that it should be `action.payload.email` instead.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

[Redux Documentation](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow) - the official documentation on Redux data flow helped me understand the process of calling dispatch (which runs the store's reducer function) to update state.

Closes Shift3#4
