### PR TITLE
Issue #6 Solution

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,6 +1,14 @@
 import React from "react";
+import { connect } from "react-redux";
 import { Link } from "react-router-dom";
+import { logoutUser } from "../../redux/actions/authActions";
 import "./nav.css";
+
+const mapActionsToProps = dispatch => ({
+    commenceLogout() {
+      dispatch(logoutUser());
+    }
+})
 
 const Nav = (props) => {
     return (
@@ -15,7 +23,7 @@ const Nav = (props) => {
                     <label className="nav-label">View Orders</label>
                 </div>
             </Link>
-            <Link to={"/login"} className="nav-link">
+            <Link to={"/"} className="nav-link" onClick={props.commenceLogout}>
                 <div className="nav-link-style">
                     <label className="nav-label">Log Out</label>
                 </div>
@@ -24,4 +32,4 @@ const Nav = (props) => {
     );
 }
 
-export default Nav;
+export default connect(null, mapActionsToProps)(Nav);

--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders} from '../components';
+import AuthGuard from './route-guards/authGuard';
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <AuthGuard>
+        <Route path="/order" exact component={OrderForm} />
+        <Route path="/view-orders" exact component={ViewOrders} />
+      </AuthGuard>
     </Router>
   );
 }

--- a/application/src/router/route-guards/authGuard.js
+++ b/application/src/router/route-guards/authGuard.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+const AuthGuard = (props) => {
+    const auth = useSelector((state) => state.auth);
+    
+    /**
+     * If the user is authenticated, we want to return the child Route
+     * components that are wrapped within this AuthGuard. Otherwise,
+     * we want to redirect the user back to the welcome page.
+     */
+    return auth.token
+        ? props.children
+        : <Redirect to="/" />
+}
+
+export default AuthGuard;

--- a/application/src/router/route-guards/authGuard.js
+++ b/application/src/router/route-guards/authGuard.js
@@ -8,11 +8,11 @@ const AuthGuard = (props) => {
     /**
      * If the user is authenticated, we want to return the child Route
      * components that are wrapped within this AuthGuard. Otherwise,
-     * we want to redirect the user back to the welcome page.
+     * we want to redirect the user back to the login page.
      */
     return auth.token
         ? props.children
-        : <Redirect to="/" />
+        : <Redirect to="/login" />
 }
 
 export default AuthGuard;


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Created a new `AuthGuard` component to act as a wrapper for any routes that require a user to be logged in.
2. Updated `AppRouter` by wrapping the routes for /order and /view-orders within the new `AuthGuard` component.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/6

## Approach
_How does this change address the problem?_

We are now checking state for auth data before allowing a user access to any routes that are wrapped within the route guard. If there is no auth data in state, the route guard redirects the user to the login page. This means users can no longer add or view orders without being logged in.

## Pre-Testing TODOs
_What needs to be done before testing_
- There are no pre-testing steps for this feature.

## Testing Steps
_How do the users test this change?_
1. Attempt to navigate to http://localhost:3000/order and http://localhost:3000/view-orders
2. Verify that you are redirected to the login page for both routes.
3. Login via the login page.
4. Verify that you are now able to navigate between the order and view-orders pages.

## Learning
_Describe the research stage_

I knew there could be a few ways to tackle this, so I did a bit of research on different methods of implementing route guards. One method that I found was to create a new component that returns `Route` or `Redirect` based on the check for auth data. This is very similar to my approach, but I thought it might be cleaner to create a wrapper component instead. So I created a new `AuthGuard` component that can simply wrap any of the routes that we want to protect within `AppRouter`. With this approach, we either return `props.children` (which would be any of the child route components wrapped within `AuthGuard`) or `Redirect` based on the check for auth data.

Conclusion: I think both of the methods described above are valid solutions, and I went with a wrapper out of preference. After implementing my solution I ended up finding a blog post that took a pretty similar approach as me, which was nice verification that my method was valid.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

[Protected Routes and Authentication with React Router](https://ui.dev/react-router-protected-routes-authentication)

Closes Shift3#6
