### PR TITLE
Issue #8 Solution

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -1,12 +1,34 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { deleteOrder } from '../../redux/actions/orderActions';
+
+const mapActionsToProps = dispatch => ({
+    commenceDeleteOrder(order) {
+        dispatch(deleteOrder(order._id));
+    }
+})
 
 const OrdersList = (props) => {
+    let history = useHistory();
+
     const { orders } = props;
     if (!props || !props.orders || !props.orders.length) return (
         <div className="empty-orders">
             <h2>There are no orders to display</h2>
         </div>
     );
+
+    const promptEditForm = (order) => {
+        history.push({
+            pathname: '/order',
+            state: { order }
+        });
+    }
+
+    const deleteOrder = (order) => {
+       props.commenceDeleteOrder(order);
+    }
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
@@ -21,12 +43,12 @@ const OrdersList = (props) => {
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
+                    <button className="btn btn-success" onClick={() => promptEditForm(order)}>Edit</button>
+                    <button className="btn btn-danger" onClick={() => deleteOrder(order)}>Delete</button>
                 </div>
             </div>
         );
     });
 }
 
-export default OrdersList;
+export default connect(null, mapActionsToProps)(OrdersList);

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,0 +1,51 @@
+import { SERVER_IP } from '../../private'
+
+export const addOrder = (order_item, quantity, ordered_by) => {
+    return() => {
+        fetch(`${SERVER_IP}/api/add-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                order_item,
+                quantity,
+                ordered_by
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => res.json())
+        .then(response => console.log("Success", JSON.stringify(response)))
+        .catch(error => console.error(error));
+    };
+}
+
+export const editOrder = (id, order_item, quantity, ordered_by) => {
+    return () => {
+        fetch(`${SERVER_IP}/api/edit-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                id,
+                order_item,
+                ordered_by,
+                quantity
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        }).then(response => response.json())
+    };
+}
+
+export const deleteOrder = (id) => {
+    return () => {
+        fetch(`${SERVER_IP}/api/delete-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        }).then(response => response.json())
+    };
+}


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Created `orderActions` to hold redux actions for any of our order-related endpoints (add, edit, and delete orders). This change was made as a way to cleanup `OrderForm` before modifying it to handle editing orders.
2. Modified `OrderForm` to handle both adding/editing orders. The form submits an `editOrder` action if an order was passed into it via `props.location.state`. If no order was passed in via props, then it submits an `addOrder` action. Also, the text on the submit button as well as the header label are different based on if we're adding or editing an order (UI touch-up).
3. Modified `OrderList` to provide functionality for the edit/delete buttons. If the edit button is clicked, we are routed to the order page with the selected order passed into `OrderForm` via `props.location.state`. If the delete button is clicked, then the `deleteOrder` action is called.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/8
- Description: The feature request was to implement functionality for the edit/delete buttons on the view-orders page. The request also specified leveraging existing components to keep the code as DRY as possible.

## Approach
_How does this change address the problem?_

This change adds functionality for the edit and delete buttons, and keeps the code DRY by modifying the existing `OrderForm` to handle both adding and editing orders (rather than making separate components for both actions).

## Pre-Testing TODOs
_What needs to be done before testing_
- There are no pre-testing steps for this feature.

## Testing Steps
_How do the users test this change?_
1. Go to the 'order' page and create a new order, then navigate to the 'view-orders' page to make sure your order was successfully created.
2. From the 'view-orders' page, click the 'Edit' button to be taken back to the 'order' page.
3. Upon returning to the 'order' page, make sure the header label now says 'Editing my order...'. The submit button should now also say 'Edit Order!' instead of 'Order It!'.
4. After editing the order, navigate back to the 'view-orders' page and make sure the order was successfully edited.
5. Click the 'Delete' button and refresh the 'view-orders' page. Make sure the order was successfully deleted.

## Learning
_Describe the research stage_

While I did not need to look into outside blogs or documentation for this task, I did certainly utilize what I learned from Shift3#7. For example, after learning about the React Router `useHistory()` hook during that task, I applied that knowledge to this task for navigating from the 'view-orders' page to the 'order' page while passing in the selected order via `props.location.state`. It was also helpful to see how `authActions` was setup for our login/logout endpoints, and I was able to apply that same structure when creating `orderActions` for our order-related endpoints. 

Closes Shift3#8
