### PR TITLE
Issue #9 Solution

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -1,12 +1,34 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { deleteOrder } from '../../redux/actions/orderActions';
+
+const mapActionsToProps = dispatch => ({
+    commenceDeleteOrder(order) {
+        dispatch(deleteOrder(order._id));
+    }
+})
 
 const OrdersList = (props) => {
+    let history = useHistory();
+
     const { orders } = props;
     if (!props || !props.orders || !props.orders.length) return (
         <div className="empty-orders">
             <h2>There are no orders to display</h2>
         </div>
     );
+
+    const promptEditForm = (order) => {
+        history.push({
+            pathname: '/order',
+            state: { order }
+        });
+    }
+
+    const deleteOrder = (order) => {
+       props.commenceDeleteOrder(order);
+    }
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
@@ -21,12 +43,12 @@ const OrdersList = (props) => {
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
+                    <button className="btn btn-success" onClick={() => promptEditForm(order)}>Edit</button>
+                    <button className="btn btn-danger" onClick={() => deleteOrder(order)}>Delete</button>
                 </div>
             </div>
         );
     });
 }
 
-export default OrdersList;
+export default connect(null, mapActionsToProps)(OrdersList);

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,23 +1,22 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
+import { connect, useSelector } from 'react-redux';
 import { Template } from '../../components';
-import { SERVER_IP } from '../../private';
+import { currentOrders } from '../../redux/actions/orderActions';
 import OrdersList from './ordersList';
 import './viewOrders.css';
 
-export default function ViewOrders(props) {
-    const [orders, setOrders] = useState([]);
+const mapActionsToProps = dispatch => ({
+    retrieveCurrentOrders() {
+        dispatch(currentOrders());
+    }
+})
+
+const ViewOrders = (props) => {
+    const { orders } = useSelector((state) => state.orders)
 
     useEffect(() => {
-        fetch(`${SERVER_IP}/api/current-orders`)
-            .then(response => response.json())
-            .then(response => {
-                if(response.success) {
-                    setOrders(response.orders);
-                } else {
-                    console.log('Error getting orders');
-                }
-            });
-    }, [])
+       props.retrieveCurrentOrders();
+    }, [props])
 
     return (
         <Template>
@@ -29,3 +28,5 @@ export default function ViewOrders(props) {
         </Template>
     );
 }
+
+export default connect(null, mapActionsToProps)(ViewOrders);

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,4 +1,16 @@
 import { SERVER_IP } from '../../private'
+import { CURRENT_ORDERS } from './types';
+
+const finishRetrievingOrders = (orders) => {
+    return {
+        type: CURRENT_ORDERS,
+        payload: {
+            orders
+        }
+    }
+}
+
+// actions below
 
 export const addOrder = (order_item, quantity, ordered_by) => {
     return() => {
@@ -48,4 +60,18 @@ export const deleteOrder = (id) => {
             },
         }).then(response => response.json())
     };
+}
+
+export const currentOrders = () => {
+    return (dispatch) => {
+        fetch(`${SERVER_IP}/api/current-orders`)
+            .then(response => response.json())
+            .then(response => {
+                if(response.success) {
+                    dispatch(finishRetrievingOrders(response.orders));
+                } else {
+                    console.log('Error getting orders');
+                }
+            });
+    }
 }

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,0 +1,51 @@
+import { SERVER_IP } from '../../private'
+
+export const addOrder = (order_item, quantity, ordered_by) => {
+    return() => {
+        fetch(`${SERVER_IP}/api/add-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                order_item,
+                quantity,
+                ordered_by
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => res.json())
+        .then(response => console.log("Success", JSON.stringify(response)))
+        .catch(error => console.error(error));
+    };
+}
+
+export const editOrder = (id, order_item, quantity, ordered_by) => {
+    return () => {
+        fetch(`${SERVER_IP}/api/edit-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                id,
+                order_item,
+                ordered_by,
+                quantity
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        }).then(response => response.json())
+    };
+}
+
+export const deleteOrder = (id) => {
+    return () => {
+        fetch(`${SERVER_IP}/api/delete-order`, {
+            method: 'POST',
+            body: JSON.stringify({
+                id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        }).then(response => response.json())
+    };
+}

--- a/application/src/redux/actions/types.js
+++ b/application/src/redux/actions/types.js
@@ -1,2 +1,3 @@
 export const LOGIN = 'login';
 export const LOGOUT = 'logout';
+export const CURRENT_ORDERS = 'current-orders';

--- a/application/src/redux/reducers/index.js
+++ b/application/src/redux/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import TempReducer from './tempReducer';
 import authReducer from './authReducer';
+import orderReducer from './orderReducer';
 
 export default combineReducers({
   temp: TempReducer,
   auth: authReducer,
+  orders: orderReducer,
 });

--- a/application/src/redux/reducers/orderReducer.js
+++ b/application/src/redux/reducers/orderReducer.js
@@ -1,0 +1,12 @@
+import { CURRENT_ORDERS } from '../actions/types'
+
+const INITIAL_STATE = { orders: null };
+
+export default (state = INITIAL_STATE, action) => {
+    switch (action.type) {
+        case CURRENT_ORDERS:
+            return { ...state, orders: action.payload.orders }
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. From Solution 8: Created `orderActions` as a centralized location for all endpoint requests related to orders.
2. From Solution 8: Added functionality to be able to edit/delete orders, and updated `OrdersList` to call the `deleteOrder` action in `orderActions`.
3. From Solution 8: Updated `OrderForm` to handle both adding/editing orders based on if an order was to the component via `props.location.state`. Also updated the component to call the `addOrder` and `editOrder` actions in `orderActions`.
4. Created new `orderReducer` to update state with orders after calling the 'current-orders' endpoint.
5. Updated reducer index with the new `orderReducer`.
6. Added a new `currentOrders` action to `orderActions`, and removed the 'view-orders' request from the `ViewOrders` component. Since I had already moved the actions needed for adding, editing, and deleting orders in solution 8, this was the only action left to add. In solution 8, I wanted to cleanup the order form before refactoring it to handle editing orders, which worked out nicely for completing this task.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/9
- Description: It is good practice to keep our components simple, and adding API requests within our components adds unnecessary complexity. It it much cleaner to keep a centralized location for our API requests, thus the need for an API refactor.

## Approach
_How does this change address the problem?_

These changes introduce `orderActions` as a central location for managing all of our order-related API requests. This allows removing the request for submitting order from `OrderForm`, and removing the request for viewing orders from `ViewOrders`. The new requests that were added in solution 8 for editing and deleting orders are also kept in `orderActions`.

## Pre-Testing TODOs
_What needs to be done before testing_
- No pre-testing steps are required for this task, other than making sure at least 1 entry is added throughout the course of testing in order to test the 'view-orders' page.

## Testing Steps
_How do the users test this change?_
1. Go to the 'order' page and add a new order.
2. Navigate to the 'view-orders' page and make sure the order was successfully added.
3. Click the 'Edit' button for an order, you should be redirected to the 'order' page and the 'Order It!' button will now say 'Edit Order!'.
4. Click 'Edit Order!' then navigate to the 'view-orders' page. Make sure the order that you selected to edit in the previous step has been successfully modified.
5. Click the 'Delete' button then refresh the 'view-orders' page. Make sure that the order you deleted is now gone.

## Learning
_Describe the research stage_

The research for this solution primarily involved looking through React Redux documentation. I will link the hooks page used from the documentation below, but primarily I researched more on:
1. The `useEffect` hook.
2. Different approaches for reading from state (which was needed for reading the orders returned from the current-orders endpoint). I went with the `useSelector` hook as it seemed like one of the cleaner approaches that I could find, and it was already being used in `OrderForm` to pull auth state. I prefer to keep consistency when possible, and since that's how auth state was being read, I wanted to implement it that way for reading orders from state as well.

_Links to blog posts, patterns, libraries or addons used to solve this problem_
- [React Redux Hooks Documentation](https://react-redux.js.org/api/hooks)

Closes Shift3#9
