### PR TITLE
Issue #12 Solution

### DIFF
--- a/application/src/components/view-orders/viewOrders.css
+++ b/application/src/components/view-orders/viewOrders.css
@@ -31,7 +31,7 @@
     justify-content: flex-end;
 }
 
-.live-reload-duration {
+.live-reload-input {
     margin: 10px;
     width: 22%;
 }

--- a/application/src/components/view-orders/viewOrders.css
+++ b/application/src/components/view-orders/viewOrders.css
@@ -31,6 +31,21 @@
     justify-content: flex-end;
 }
 
+.live-reload-duration {
+    margin: 10px;
+    width: 22%;
+}
+
+.live-reload-countdown {
+    margin: 10px;
+}
+
+.start-live-reload-btn {
+    background: #A43F3F;
+    color: white;
+    margin: 10px;
+}
+
 @media only screen and (max-width: 768px) {
     .view-order-left-col {
         justify-content: center;

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -7,15 +7,9 @@ import './viewOrders.css';
 export default function ViewOrders(props) {
     const [orders, setOrders] = useState([]);
 
-    let duration = 20;
+    const RELOAD_LIMIT = 12;
     let interval = 5;
     let countdown = 0;
-
-    const onDurationChange = (event) => {
-        if (!isNaN(event.target.value)) {
-            duration = event.target.value;
-        }
-    }
 
     const onIntervalChange = (event) => {
         if (!isNaN(event.target.value)) {
@@ -33,6 +27,8 @@ export default function ViewOrders(props) {
             } else {
                 console.log('Error getting orders');
             }
+        }).catch(() => {
+            console.log('Error fetching orders');
         });
 
         // keep track in console each request
@@ -48,12 +44,9 @@ export default function ViewOrders(props) {
             headers: {
                 'Content-Type': 'application/json'
             },
-        })
-
-        if (!duration) {
-            // if duration is not set, default to 20
-            duration = 20;
-        }
+        }).catch(() => {
+            console.log('Error starting live reload mode');
+        });
 
         if (!interval) {
             // if interval is not set, default to 5
@@ -61,14 +54,11 @@ export default function ViewOrders(props) {
         }
 
         // set the countdown to time before starting
-        countdown = duration;
+        countdown = interval * RELOAD_LIMIT;
         document.getElementById("countdown").innerHTML = 'Countdown: ' + countdown;
 
-        // fetch orders once for the initial display, then fetch at the specified interval
-        await fetchOrders();
-
         const commenceRefresh = setInterval(async () => {
-            await fetchOrders();
+            fetchOrders();
         }, interval * 1000);
 
         const commenceCountdown = setInterval(() => {
@@ -83,13 +73,12 @@ export default function ViewOrders(props) {
 
             // stop the countdown
             clearInterval(commenceCountdown);
-        }, duration * 1000)
+        }, interval * RELOAD_LIMIT * 1000)
     }
 
     return (
         <Template>
             <div>
-                <input className="live-reload-input" type="text" id="duration" placeholder="Duration in seconds" onChange={e => onDurationChange(e)}></input>
                 <input className="live-reload-input" type="text" id="duration" placeholder="Interval in seconds" onChange={e => onIntervalChange(e)}></input>
                 <label className="live-reload-countdown" id="countdown">Countdown: {countdown}</label>
             </div>

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -7,8 +7,36 @@ import './viewOrders.css';
 export default function ViewOrders(props) {
     const [orders, setOrders] = useState([]);
 
-    useEffect(() => {
-        fetch(`${SERVER_IP}/api/current-orders`)
+    let time = 5;
+    let countdown = 0;
+
+    const onTimeChange = (event) => {
+        if (!isNaN(event.target.value)) {
+            time = event.target.value;
+        }
+    }
+
+    const startLiveReload = () => {
+        fetch(`${SERVER_IP}/api/live-mode`, {
+            method: 'POST',
+            body: JSON.stringify({
+                time
+            }),
+        })
+        .then(response => response.json())
+
+        if (!time) {
+            // if time is not set, default to 5
+            time = 5;
+        }
+
+        // set the countdown to time before starting
+        countdown = time;
+        document.getElementById("countdown").innerHTML = 'Countdown: ' + countdown;
+
+        const commenceRefresh = setInterval(() => {
+            // fetch orders
+            fetch(`${SERVER_IP}/api/current-orders`)
             .then(response => response.json())
             .then(response => {
                 if(response.success) {
@@ -17,10 +45,28 @@ export default function ViewOrders(props) {
                     console.log('Error getting orders');
                 }
             });
-    }, [])
+
+            // keep track in console each request
+            console.log('Fetched orders')
+
+            // decrement our countdown
+            countdown -= 1;
+            document.getElementById("countdown").innerHTML = 'Countdown: ' + countdown;
+        }, 1000);
+
+        setTimeout(() => {
+            // stop refreshing
+            clearInterval(commenceRefresh);
+        }, time * 1000)
+    }
 
     return (
         <Template>
+            <div>
+                <input className="live-reload-duration" type="text" id="duration" placeholder="Duration in seconds" onChange={e => onTimeChange(e)}></input>
+                <label className="live-reload-countdown" id="countdown">Countdown: {countdown}</label>
+            </div>
+            <button className="start-live-reload-btn" onClick={() => startLiveReload()}>Start Live Reload</button>
             <div className="container-fluid">
                 <OrdersList
                     orders={orders}


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added an input field for the interval (in seconds) in which the user wants orders to be added/deleted (defaults to 5).
2. Added a "Start Live Reload" button to the 'view-orders' page. While in live reload mode, orders will be added/deleted based on the interval specified by the user (the requests to the 'view-orders' endpoint is also set to that same interval).
4. Added a countdown displayed next to the interval input field. Once live reload mode starts, this countdown will start at 12 times the interval and count down to 0 (this is because the limit for live-reload mode is 12 additions/deletions).
5. Added an error check so that the interval value is only updated when the input is a valid number.

Also includes 2 `fix commits` after my original `feat commit` for this task:
- Fix 1: I realized that I misunderstood the task description and needed to implement an interval rather than a duration for live-reload mode. At this stage, I understood that the 'live-mode' endpoint needed to take in an interval, but I still did not realize that a duration was not needed (since the duration is just 12 times the interval, due to live-reload mode having a limit of 12).
- Fix 2: Now that I also realized that a duration was not needed, I implemented a fix that removed the duration input field (since I was originally planning on letting the user enter _both_  an interval as well as a duration), and set the duration to simply be 12 times the interval.

## Purpose
_Describe the problem or feature in addition to a link to the issues._
- Link to issue: https://github.com/Shift3/react-challenge-project-jan-2022/issues/12
- Description: In certain settings (such as a restaurant needing to view new orders), a user may want data to be refreshed automatically. It can be a hassle to constantly refresh the page, so there needs to be a way to automate this.

## Approach
_How does this change address the problem?_

This change gives the user an input field to specify the interval in which they want orders to be added/deleted. The duration is  set to 12 times the interval, since the limit for live-reload mode is set to 12.

## Pre-Testing TODOs
_What needs to be done before testing_
- There are no pre-testing steps for this task.

## Testing Steps
_How do the users test this change?_

1. Go to the 'view-orders' page and enter 1 for the interval and click the "Start Live Reload" button. Make sure that the orders update every second for 12 seconds.
2. Enter 2 for the interval and click the "Start Live Reload" button. Make sure that the orders update every 2 seconds for 24 seconds.
3. Repeat steps 2 and 3 for any number of intervals. Use the countdown timer to verify the intervals.
4. Enter no input for the interval and click "Start Live Reload". Make sure that the default value of 5 is used for the interval (countdown will start at 60 and orders will be updated every 5 seconds).
5. Enter random letters for the input. Just like step 4, make sure the default value of 5 is used for the interval.

## Learning
_Describe the research stage_

Originally when I completed this task, I mistook what was meant by the interval that gets passed to the 'live-mode' endpoint. For some reason, I thought it just meant the duration that live mode needed to run, and I implemented my solution to just set the duration and update orders every 1 second. After realizing my mistake, I implemented a fix (as mentioned above in the changes section) to allow the user to enter both an interval and a duration for live reload mode. I was now using the endpoint properly by passing an interval rather than a duration, but I still thought a duration was needed. After looking at the endpoint carefully, I notice the limit of 12 for the additions/deletions. This was also mentioned in the task description, so me missing that is definitely a lesson on thoroughly reading and understanding the requirements for the task before implementing a solution. After finally realizing my mistakes, I implemented my second fix commit to remove the input field for duration. Now, a user can only enter an interval, and the duration is set based on 12 times that interval.

With that said, I have 1 feature request idea for the 'live-mode' endpoint:
- Update the endpoint to allow passing in a `limit` property as well (rather than just `time` for the interval). That way, the user can adjust both to fit their needs.

Overall, this task was on the easier end compared to a couple of the previous ones (other than my misunderstanding at first), so there was not much research required. This task was largely making use of `setInterval` to establish how often orders should be added/deleted (as well as how often the 'view-orders' endpoint should be called),  and `setTimeout` to specify the duration before calling `clearInterval`.

Closes Shift3#12
